### PR TITLE
Enable management of additional hosts via Pillar

### DIFF
--- a/dnsmasq/files/dnsmasq.conf
+++ b/dnsmasq/files/dnsmasq.conf
@@ -38,9 +38,15 @@
     {%- endif %}
 {%- endmacro %}
 
-{%- for name, value in settings.iteritems() %}
+{%- set settings_items = settings.iteritems()|list %}
+{%- if addn_hosts and not 'addn-hosts' in settings %}
+{%- do settings_items.append(('addn-hosts', addn_hosts)) %}
+{%- endif %}
+
+{%- for name, value in settings_items|sort %}
 {{- print_config(name, value) }}
 {%- endfor %}
+
 ################################################################################
 
 

--- a/dnsmasq/files/dnsmasq.hosts
+++ b/dnsmasq/files/dnsmasq.hosts
@@ -1,0 +1,11 @@
+{%- set dnsmasq = pillar.get('dnsmasq', {}) -%}
+{%- set zones = dnsmasq.get('hosts', {}) -%}
+{%- for zone, hosts in zones|dictsort %}
+{%- if hosts is not mapping %}
+{{ hosts }} {{ zone }}
+{%- else %}
+{%- for host, ip in hosts|dictsort %}
+{{ ip }} {{ host }}.{{ zone }}
+{%- endfor -%}
+{%- endif %}
+{% endfor -%}

--- a/dnsmasq/init.sls
+++ b/dnsmasq/init.sls
@@ -13,11 +13,28 @@ dnsmasq_conf:
     - template: jinja
     - require:
       - pkg: dnsmasq
+{%- if salt['pillar.get']('dnsmasq:dnsmasq_hosts') %}
+    - context:
+        addn_hosts: {{ dnsmasq.dnsmasq_hosts }}
+{%- endif %}
 
 dnsmasq_conf_dir:
   file.recurse:
     - name: {{ dnsmasq.dnsmasq_conf_dir }}
     - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_conf_dir', 'salt://dnsmasq/files/dnsmasq.d') }}
+    - template: jinja
+    - require:
+      - pkg: dnsmasq
+{%- endif %}
+
+{%- if salt['pillar.get']('dnsmasq:dnsmasq_hosts') %}
+dnsmasq_hosts:
+  file.managed:
+    - name: {{ dnsmasq.dnsmasq_hosts }}
+    - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_hosts', 'salt://dnsmasq/files/dnsmasq.hosts') }}
+    - user: root
+    - group: root
+    - mode: 644
     - template: jinja
     - require:
       - pkg: dnsmasq
@@ -34,4 +51,7 @@ dnsmasq:
     - watch:
       - file: dnsmasq_conf
       - file: dnsmasq_conf_dir
+{%- endif %}
+{%- if salt['pillar.get']('dnsmasq:dnsmasq_hosts') %}
+      - file: dnsmasq_hosts
 {%- endif %}

--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -3,16 +3,19 @@
         'service': 'dnsmasq',
         'dnsmasq_conf': '/etc/dnsmasq.conf',
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
+        'dnsmasq_hosts': '/etc/dnsmasq.hosts',
     },
     'RedHat': {
         'service': 'dnsmasq',
         'dnsmasq_conf': '/etc/dnsmasq.conf',
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
+        'dnsmasq_hosts': '/etc/dnsmasq.hosts',
     },
     'Arch': {
       'service': 'dnsmasq',
       'dnsmasq_conf': '/etc/dnsmasq.conf',
       'dnsmasq_conf_dir': '/etc/dnsmasq.d',
+      'dnsmasq_hosts': '/etc/dnsmasq.hosts',
     },
 } %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 # Example settings for dnsmasq.
 dnsmasq:
   dnsmasq_conf: salt://dnsmasq/files/dnsmasq.conf
+  dnsmasq_hosts: salt://dnsmasq/files/dnsmasq.hosts
   dnsmasq_conf_dir: salt://dnsmasq/files/dnsmasq.d
 
   # Customize dnsmasq settings below - any valid dnsmasq configuration file
@@ -28,3 +29,17 @@ dnsmasq:
     domain-needed: True
     # Never forward addresses in the non-routed address spaces?
     bogus-priv: True
+
+  # Add extra entries to the DNS or override existing ones
+  # (e.g. for split horizon usage)
+  # The domain will automatically be appended if its part of a mapping
+  # It is recommended to group common domains in a mapping to prevent
+  # duplicated names in Pillar and to make it easier to
+  hosts:
+    example.com:
+      dns: 10.10.10.1
+      vpn: 10.10.10.2
+    example.net:
+      www: 10.10.10.3
+      mail: 10.10.10.4
+    test.example.org: 10.10.10.5


### PR DESCRIPTION
This is an enhancement/improvement of #3 allowing either grouping per domain (auto-append) or simple entries to be added.
Tested on Ubuntu 14.04 (Salt 2014.7.0)