### PR TITLE
Let dnsmasq.conf template work when not using addn-hosts

### DIFF
--- a/dnsmasq/files/dnsmasq.conf
+++ b/dnsmasq/files/dnsmasq.conf
@@ -39,7 +39,7 @@
 {%- endmacro %}
 
 {%- set settings_items = settings.iteritems()|list %}
-{%- if addn_hosts and not 'addn-hosts' in settings %}
+{%- if addn_hosts is defined and not 'addn-hosts' in settings %}
 {%- do settings_items.append(('addn-hosts', addn_hosts)) %}
 {%- endif %}
 


### PR DESCRIPTION
The state will fail with an error if you using addn-hosts.  This change allows the state to work by checking if the variable is defined (which appeared to be the intent in any case).