### PR TITLE
add support for SUSE Linux

### DIFF
--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -13,6 +13,13 @@
         'dnsmasq_hosts': '/etc/dnsmasq.hosts',
         'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
     },
+    'Suse': {
+        'service': 'dnsmasq',
+        'dnsmasq_conf': '/etc/dnsmasq.conf',
+        'dnsmasq_conf_dir': '/etc/dnsmasq.d',
+        'dnsmasq_hosts': '/etc/dnsmasq.d/hosts',
+        'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+    },
     'Arch': {
       'service': 'dnsmasq',
       'dnsmasq_conf': '/etc/dnsmasq.conf',


### PR DESCRIPTION
e.g. openSUSE and SUSE Linux Enterprise (SLE)

using /etc/dnsmasq.d/hosts to remain within existing apparmor profiles