### PR TITLE
Add support for FreeBSD

### DIFF
--- a/dnsmasq/init.sls
+++ b/dnsmasq/init.sls
@@ -8,7 +8,7 @@ dnsmasq_conf:
     - name: {{ dnsmasq.dnsmasq_conf }}
     - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_conf', 'salt://dnsmasq/files/dnsmasq.conf') }}
     - user: root
-    - group: root
+    - group: {{ dnsmasq.group }}
     - mode: 644
     - template: jinja
     - require:
@@ -33,7 +33,7 @@ dnsmasq_hosts:
     - name: {{ dnsmasq.dnsmasq_hosts }}
     - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_hosts', 'salt://dnsmasq/files/dnsmasq.hosts') }}
     - user: root
-    - group: root
+    - group: {{ dnsmasq.group }}
     - mode: 644
     - template: jinja
     - require:
@@ -48,7 +48,7 @@ dnsmasq_cnames:
     - name: {{ dnsmasq.dnsmasq_cnames }}
     - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_cnames', 'salt://dnsmasq/files/dnsmasq.cnames') }}
     - user: root
-    - group: root
+    - group: {{ dnsmasq.group }}
     - mode: 644
     - template: jinja
     - require:

--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -5,6 +5,7 @@
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
         'dnsmasq_hosts': '/etc/dnsmasq.hosts',
         'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+        'group': 'root',
     },
     'RedHat': {
         'service': 'dnsmasq',
@@ -12,6 +13,7 @@
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
         'dnsmasq_hosts': '/etc/dnsmasq.hosts',
         'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+        'group': 'root',
     },
     'Arch': {
       'service': 'dnsmasq',
@@ -19,6 +21,7 @@
       'dnsmasq_conf_dir': '/etc/dnsmasq.d',
       'dnsmasq_hosts': '/etc/dnsmasq.hosts',
       'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+      'group': 'root',
     },
     'FreeBSD': {
       'service': 'dnsmasq',
@@ -26,6 +29,7 @@
       'dnsmasq_conf_dir': '/usr/local/etc/dnsmasq.d',
       'dnsmasq_hosts': '/usr/local/etc/dnsmasq.hosts',
       'dnsmasq_cnames': '/usr/local/etc/dnsmasq.d/cnames.conf',
+      'group': 'wheel',
     },
 } %}
 

--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -20,9 +20,17 @@
       'dnsmasq_hosts': '/etc/dnsmasq.hosts',
       'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
     },
+    'FreeBSD': {
+      'service': 'dnsmasq',
+      'dnsmasq_conf': '/usr/local/etc/dnsmasq.conf',
+      'dnsmasq_conf_dir': '/usr/local/etc/dnsmasq.d',
+      'dnsmasq_hosts': '/usr/local/etc/dnsmasq.hosts',
+      'dnsmasq_cnames': '/usr/local/etc/dnsmasq.d/cnames.conf',
+    },
 } %}
 
-{% if grains.get('saltversion', '').startswith('0.17') %}
+{% set saltversion=grains.get('saltversion, '') %}
+{% if saltversion.startswith('0.17') or saltversion.startswith('2') %} {# y3k problem #}
 {% set dnsmasq = salt['grains.filter_by'](map, merge=salt['pillar.get']('dnsmasq:lookup')) %}
 {% else %}
 {% set dnsmasq = map.get(grains.os_family) %}

--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -29,7 +29,7 @@
     },
 } %}
 
-{% set saltversion=grains.get('saltversion, '') %}
+{% set saltversion=grains.get('saltversion', '') %}
 {% if saltversion.startswith('0.17') or saltversion.startswith('2') %} {# y3k problem #}
 {% set dnsmasq = salt['grains.filter_by'](map, merge=salt['pillar.get']('dnsmasq:lookup')) %}
 {% else %}


### PR DESCRIPTION
Also permit pillar lookups for recent Salt versions, in case of other unknown operating systems.
Fix #14