### PR TITLE
Added support for addresses, which allows for wildcard lookups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,22 +5,41 @@ dnsmasq-formula
 ``dnsmasq`` provides DNS services, as well as optional DHCP and TFTP services.
 
 Available States
-=================
+================
 
 .. contents::
     :local:
 
 ``dnsmasq``
--------------------
+-----------
 
 Install the dnsmasq package, start the service and apply custom settings.
 
 
 ``dnsmasq.absent``
--------------------
+------------------
 
 Remove the dnsmasq package, and stop the associated dnsmasq service.
 
+``Example pillar configuration``
+--------------------------------
+
+.. code-block:: yaml
+
+  dnsmasq:
+    addresses:
+      test.com: 1.2.3.4
+      another.org: 2.3.4.5
+
+    cnames:
+      mydomain.com:
+        domain01: server01.cloud.com
+        domain02: server42.cloud.com
+
+    hosts:
+      cloud.com:
+        server01: 1.0.0.1
+        server42: 1.0.0.42
 
 Additional resources
 ======================

--- a/dnsmasq/files/dnsmasq.addresses
+++ b/dnsmasq/files/dnsmasq.addresses
@@ -1,0 +1,5 @@
+{%- set dnsmasq = pillar.get('dnsmasq', {}) -%}
+{%- set addresses = dnsmasq.get('addresses', {}) -%}
+{%- for address, destination in addresses|dictsort -%}
+address=/{{ address }}/{{ destination }}
+{% endfor -%}

--- a/dnsmasq/init.sls
+++ b/dnsmasq/init.sls
@@ -57,6 +57,21 @@ dnsmasq_cnames:
       - service: dnsmasq
 {%- endif %}
 
+{%- if salt['pillar.get']('dnsmasq:dnsmasq_addresses') %}
+dnsmasq_addresses:
+  file.managed:
+    - name: {{ dnsmasq.dnsmasq_addresses }}
+    - source: {{ salt['pillar.get']('dnsmasq:dnsmasq_addresses', 'salt://dnsmasq/files/dnsmasq.addresses') }}
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - require:
+      - pkg: dnsmasq
+    - watch_in:
+      - service: dnsmasq
+{%- endif %}
+
 dnsmasq:
   pkg.installed: []
   service.running:

--- a/dnsmasq/map.jinja
+++ b/dnsmasq/map.jinja
@@ -5,6 +5,7 @@
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
         'dnsmasq_hosts': '/etc/dnsmasq.hosts',
         'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+        'dnsmasq_addresses': '/etc/dnsmasq.d/addresses.conf',
     },
     'RedHat': {
         'service': 'dnsmasq',
@@ -12,6 +13,7 @@
         'dnsmasq_conf_dir': '/etc/dnsmasq.d',
         'dnsmasq_hosts': '/etc/dnsmasq.hosts',
         'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+        'dnsmasq_addresses': '/etc/dnsmasq.d/addresses.conf',
     },
     'Arch': {
       'service': 'dnsmasq',
@@ -19,6 +21,7 @@
       'dnsmasq_conf_dir': '/etc/dnsmasq.d',
       'dnsmasq_hosts': '/etc/dnsmasq.hosts',
       'dnsmasq_cnames': '/etc/dnsmasq.d/cnames.conf',
+      'dnsmasq_addresses': '/etc/dnsmasq.d/addresses.conf',
     },
 } %}
 


### PR DESCRIPTION
This adds support to this formula to configure things like this:
`address=/mydomain.com/1.2.3.4`

This makes it possible to have every subdomain of mydomain.com (no matter how many levels) resolve to 1.2.3.4. automagically :)

