### PR TITLE
iteritems() -> items() (Python 3.6)

### DIFF
--- a/dnsmasq/files/dnsmasq.conf
+++ b/dnsmasq/files/dnsmasq.conf
@@ -38,7 +38,7 @@
     {%- endif %}
 {%- endmacro %}
 
-{%- set settings_items = settings.iteritems()|list %}
+{%- set settings_items = settings.items()|list %}
 {%- if addn_hosts is defined and not 'addn-hosts' in settings %}
 {%- do settings_items.append(('addn-hosts', addn_hosts)) %}
 {%- endif %}


### PR DESCRIPTION
Ensure Python 3.6 compatibility.

Tested on FreeBSD 11.2 with `salt-ssh` to Ubuntu 18.04.