### PR TITLE
Support multiple A entries in hosts for HA setups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ Remove the dnsmasq package, and stop the associated dnsmasq service.
       cloud.com:
         server01: 1.0.0.1
         server42: 1.0.0.42
+      available.com:
+        - 1.1.1.1
+        - 1.1.1.2
+        - 1.1.1.3
 
 Additional resources
 ======================

--- a/dnsmasq/files/dnsmasq.hosts
+++ b/dnsmasq/files/dnsmasq.hosts
@@ -1,11 +1,15 @@
 {%- set dnsmasq = pillar.get('dnsmasq', {}) -%}
 {%- set zones = dnsmasq.get('hosts', {}) -%}
 {%- for zone, hosts in zones|dictsort %}
-{%- if hosts is not mapping %}
-{{ hosts }} {{ zone }}
-{%- else %}
+{%- if hosts is mapping %}
 {%- for host, ip in hosts|dictsort %}
 {{ ip }} {{ host }}.{{ zone }}
+{%- endfor -%}
+{%- elif hosts is string %}
+{{ hosts }} {{ zone }}
+{%- elif hosts is sequence %}
+{%- for ip in hosts %}
+{{ ip }} {{ zone }}
 {%- endfor -%}
 {%- endif %}
 {% endfor -%}


### PR DESCRIPTION
This PR allows ones to provide a list of addresses for a given host, which is required for HA setups.